### PR TITLE
add EstUAVLocation.msg

### DIFF
--- a/Messages/EstUAVLocation.msg
+++ b/Messages/EstUAVLocation.msg
@@ -1,0 +1,10 @@
+# EstUAVLocation.msg
+# Message describing estimated current location of the UAV.  Published by communications every time a new LOCAL_POSITION_NED comes in from the UAV.
+
+time timestamp
+float64 x
+float64 y
+float64 z
+float64 vel_x
+float64 vel_y
+float64 vel_z


### PR DESCRIPTION
Here's the first message.  It has the same function as [Kris' original message on bitbucket](https://bitbucket.org/mrkris13/uav-msgs/src/8beb3906c9d8546234f5374a7bcc6f3892e8cb01/msg/EstUavState.msg?at=master&fileviewer=file-view-default).  The main difference is that it does not include angles (yaw,pitch,roll).  Since we have a gimbal, I don't think these are needed (velocity is already there).

The UAV sends a MAVLink message called [LOCAL_POSITION_NED](http://mavlink.org/messages/common#LOCAL_POSITION_NED) at whatever rate we want, and the comms node will just parse it into this message and send it.  If you look at the definition of this MAVlink message, you'll notice that it's pretty much the same thing.
